### PR TITLE
Fixing comparison error in svc_cmp

### DIFF
--- a/k8s-svc-gw-mgr/app.js
+++ b/k8s-svc-gw-mgr/app.js
@@ -94,7 +94,7 @@ app.get('/', function(req, res) {
 var server = app.listen(mgr_port);
 
 function svc_cmp(a, b) {
-  if (a.svc > b.svc)
+  if (a.svc < b.svc)
     return -1;
   if (a.svc > b.svc)
     return 1;


### PR DESCRIPTION
Looks like there was a logic error in the `svc_cmp` function. Both conditionals check `a.svc > b.svc`. According to the MDN docs for `Array.prototype.sort()`, if `a` is less than `b` the function should return `-1`:

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/sort
