### PR TITLE
Add https auth for k8s api host

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ The service gateway checks for updates every minute, though that's configurable 
 
 | ENV Var                           | Description
 | --------------------------------- | -----------
-| SVC_GW_K8S_API_HOST               | which kubernetes API to connect to. Defaults to $KUBERNETES_RO_SERVICE_HOST.
+| SVC_GW_K8S_API_HOST               | which kubernetes API to connect to. Defaults to $KUBERNETES_SERVICE_HOST.
 | SVC_GW_PREFIX                     | which annotation prefix to look for. Defaults to 'svcgateway'.
 | SVC_GW_ERR_PREFIX                 | which annotation prefix to look for if error capturing should take effect. Default is "err.svcproxy."
 | SVC_GW_CIDR                       | which annotation prefix to look for cidr block whitelisting. Default is "cidr."


### PR DESCRIPTION
Seems like for Kubernetes v1.0 onwards, access to the api service must be done over https, using the credentials in a secret provided within the pod itself.

http://kubernetes.io/v1.0/docs/user-guide/accessing-the-cluster.html#accessing-the-api-from-a-pod

From this documentation it seems clear that the location of the secrets are defined, but I haven't tested on anything but GCE, so I can't confirm if other kubernetes deployments do it differently. 
